### PR TITLE
Fix/editorconfig path

### DIFF
--- a/basic/plugins.vim
+++ b/basic/plugins.vim
@@ -14,8 +14,6 @@ Plug 'vim-syntastic/syntastic'
 
 Plug 'mkitt/tabline.vim'
 
-Plug 'editorconfig/editorconfig-vim'
-
 " ----------------------------------------------------------------
 "  Completion plugins
 " ----------------------------------------------------------------
@@ -50,4 +48,4 @@ Plug 'ternjs/tern_for_vim'
 
 Plug 'maksimr/vim-jsbeautify'
 
-cal plug#end()
+call plug#end()

--- a/basic/plugins.vim
+++ b/basic/plugins.vim
@@ -14,8 +14,6 @@ Plug 'vim-syntastic/syntastic'
 
 Plug 'mkitt/tabline.vim'
 
-Plug 'editorconfig/editorconfig-vim'
-
 " ----------------------------------------------------------------
 "  Completion plugins
 " ----------------------------------------------------------------
@@ -48,4 +46,4 @@ Plug 'ternjs/tern_for_vim'
 
 Plug 'maksimr/vim-jsbeautify'
 
-cal plug#end()
+call plug#end()

--- a/basic/plugins.vim
+++ b/basic/plugins.vim
@@ -14,6 +14,8 @@ Plug 'vim-syntastic/syntastic'
 
 Plug 'mkitt/tabline.vim'
 
+Plug 'editorconfig/editorconfig-vim'
+
 " ----------------------------------------------------------------
 "  Completion plugins
 " ----------------------------------------------------------------
@@ -46,4 +48,4 @@ Plug 'ternjs/tern_for_vim'
 
 Plug 'maksimr/vim-jsbeautify'
 
-call plug#end()
+cal plug#end()

--- a/languages/javascript.vim
+++ b/languages/javascript.vim
@@ -3,7 +3,7 @@ autocmd FileType javascript noremap <buffer>  <leader>g :TernDef<cr>
 autocmd FileType javascript noremap <buffer>  <leader>r :TernRename<cr>
 autocmd FileType javascript noremap <buffer>  <leader>d :TernDoc<cr>
 
-let g:editorconfig_Beautifier = "~/.SUCH-Vim/languages/js-beautify"
+let g:editorconfig_Beautifier = "~/Documents/Github/Config/neovim/languages/js-beautify"
 
 
 

--- a/languages/javascript.vim
+++ b/languages/javascript.vim
@@ -1,6 +1,7 @@
-autocmd FileType javascript noremap <buffer> <leader>f :call JsBeautify()<cr>
-autocmd FileType javascript noremap <buffer> <leader>g :TernDef<cr>
-autocmd FileType javascript noremap <buffer> <leader>r :TernRename<cr>
-autocmd FileType javascript noremap <buffer> <leader>d :TernDoc<cr>
 autocmd FileType javascript autocmd BufWritePre <buffer> call JsBeautify()
-let g:editorconfig_Beautifier = "~/Documents/Github/Config/neovim/languages/js-beautify"
+autocmd FileType javascript noremap <buffer>  <leader>f :call JsBeautify()<cr>
+autocmd FileType javascript noremap <buffer>  <leader>g :TernDef<cr>
+autocmd FileType javascript noremap <buffer>  <leader>r :TernRename<cr>
+autocmd FileType javascript noremap <buffer>  <leader>d :TernDoc<cr>
+
+let g:editorconfig_Beautifier = "~/.SUCH-Vim/languages/js-beautify"

--- a/languages/javascript.vim
+++ b/languages/javascript.vim
@@ -3,7 +3,7 @@ autocmd FileType javascript noremap <buffer>  <leader>g :TernDef<cr>
 autocmd FileType javascript noremap <buffer>  <leader>r :TernRename<cr>
 autocmd FileType javascript noremap <buffer>  <leader>d :TernDoc<cr>
 
-let g:editorconfig_Beautifier = "~/Documents/Github/Config/neovim/languages/js-beautify"
+let g:editorconfig_Beautifier = "~/.SUCH-Vim/languages/js-beautify"
 
 
 


### PR DESCRIPTION
There was an error in the path to the global .editorconfig file for JSBeautifier. It should remove the warning at the start of Vim. Fix a typo in plugins.vim also. 