### PR TITLE
Auto-refresh NERDTree when there is changes in the file tree on disk

### DIFF
--- a/config/environment/buffer.vim
+++ b/config/environment/buffer.vim
@@ -3,6 +3,7 @@
 " ----------------------------------------------------------------
 
 autocmd bufenter * if (winnr("$") == 1 && exists("b:NERDTree") && b:NERDTree.isTabTree()) | q | endif
+autocmd CursorHold,CursorHoldI * call NERDTreeFocus() | call g:NERDTree.ForCurrentTab().getRoot().refresh() | call g:NERDTree.ForCurrentTab().render() | wincmd w
 nnoremap <leader>tt :NERDTreeToggle<CR>
 
 " ----------------------------------------------------------------


### PR DESCRIPTION
What it does in a nutshell :

autocmd CursorHold,CursorHoldI ... : Everytime there is no cursor movement/keypress in Vim for more than 4 sec (As it does for Vim autosave for swp files) - i.e. when we are messing with files outside

...  * call NERDTreeFocus() ... : Focus on NERDTree's buffer

... | call g:NERDTree.ForCurrentTab().getRoot().refresh() ... : And refresh file tree

... | call g:NERDTree.ForCurrentTab().render() ... : And re-render his buffer in order to see changes

... | wincmd w : And give focus back to the buffer we were working on.

Works flawlessly - <3