### PR TITLE
A start in portability

### DIFF
--- a/common/config/basic/practical.vim
+++ b/common/config/basic/practical.vim
@@ -10,8 +10,6 @@ set nowrap
 "  UI Setup
 " ----------------------------------------------------------------
 
-set termguicolors
-set background=dark
 let g:airline#extensions#tabline#enabled = 1
 let g:airline#extensions#tabline#fnamemod = ':t'
 let g:Powerline_symbols = 'unicode'


### PR DESCRIPTION

These two lines :
`set termguicolors`
`set background=dark`

should go in personnal configs, for they won't work with every terminal emulator
----> It was breaking my vim :'(