### PR TITLE
Add dependency management with Cargo for Rust projects

### DIFF
--- a/suchvim/dependencies/cargo_dependencies.vim
+++ b/suchvim/dependencies/cargo_dependencies.vim
@@ -1,0 +1,33 @@
+let s:SUCHVim_cargo_path = $HOME."/.vim/SUCH-Vim/dependencies/cargo/"
+let $PATH .= ':'.s:SUCHVim_cargo_path.'bin'
+
+function! SUCHVim_check_cargo_dependencies(dependencies)
+    let missing_dependencies = SUCHVim_check_dependencies(a:dependencies)
+    if len(missing_dependencies) != 0
+        if SUCHVim_check_dependency("cargo") == 1
+            let cargo_dependency_commands = SUCHVim_install_cargo_dependencies(missing_dependencies)
+            call SUCHVim_execute_dependency_commands(cargo_dependency_commands)
+        else
+            let cargo_dependency_message = SUCHVim_echo_cargo_dependencies(missing_dependencies)
+            call SUCHVim_echo_dependency_commands(cargo_dependency_message)
+        endif
+    endif
+endfunction
+
+function! SUCHVim_install_cargo_dependencies(dependencies)
+    let cargo_install_command = "!cargo install --root ".s:SUCHVim_cargo_path
+    let install_commands = []
+    for dependency in a:dependencies
+        call add(install_commands, cargo_install_command." ".dependency)
+    endfor
+    return install_commands
+endfunction
+
+function! SUCHVim_echo_cargo_dependencies(dependencies)
+    let message = "There are missing dependencies [ "
+    for dependency in a:dependencies
+        let message = message.dependency." "
+    endfor
+    let message = message."], install cargo or install them manualy." 
+    return message
+endfunction

--- a/suchvim/suchvim.vim
+++ b/suchvim/suchvim.vim
@@ -5,6 +5,7 @@
 source ~/.SUCH-Vim/suchvim/dependencies/dependencies.vim
 source ~/.SUCH-Vim/suchvim/dependencies/npm_dependencies.vim
 source ~/.SUCH-Vim/suchvim/dependencies/pip_dependencies.vim
+source ~/.SUCH-Vim/suchvim/dependencies/cargo_dependencies.vim
 
 " ----------------------------------------------------------------
 "  General utilities

--- a/tests/unittests/suchvim/dependencies/cargo_dependencies.vader
+++ b/tests/unittests/suchvim/dependencies/cargo_dependencies.vader
@@ -1,0 +1,125 @@
+Before (setUp):
+  let SUCHVim_cargo_path = $HOME."/.vim/SUCH-Vim/dependencies/cargo/"
+  source ~/.SUCH-Vim/tests/unittests/suchvim/dependencies/mocks/dependencies.vim
+  source ~/.SUCH-Vim/suchvim/dependencies/cargo_dependencies.vim
+
+  let dependency_name = "rustfmt"
+  let other_dependency_name = "cargo-watch"
+  let installed_dependency_name = "cargo-multi"
+
+  let not_installed_dependency = []
+  call add(not_installed_dependency, dependency_name)
+
+  let not_installed_dependencies = []
+  call add(not_installed_dependencies, dependency_name)
+  call add(not_installed_dependencies, other_dependency_name)
+  
+  let installed_dependency = []
+  call add(installed_dependency, installed_dependency_name)
+  
+  let dependencies = []
+  call add(dependencies, dependency_name)
+  call add(dependencies, other_dependency_name)
+  call add(dependencies, installed_dependency_name)
+  
+  let installed_dependencies = []
+  call add(installed_dependencies, installed_dependency_name)
+
+Execute (Given not installed dependency When install Then command is correct):
+  let dependency_commands = SUCHVim_install_cargo_dependencies(not_installed_dependency)
+
+  let expected = "!cargo install --root ".SUCHVim_cargo_path." ".dependency_name
+  Assert expected == dependency_commands[0]
+
+Execute (Given not installed dependency When echo Then message is correct):
+  let dependency_message = SUCHVim_echo_cargo_dependencies(not_installed_dependency)
+
+  let expected = "There are missing dependencies [ ".dependency_name." ], install cargo or install them manualy."
+  Assert expected == dependency_message
+
+Execute (Given not installed dependency and has cargo When check Then command is correct):
+  call SUCHVim_set_not_installed_dependencies(not_installed_dependency)
+  call SUCHVim_set_check_dependency(1)
+
+  call SUCHVim_check_cargo_dependencies(not_installed_dependency)
+
+  let expected = []
+  call add(expected, "!cargo install --root ".SUCHVim_cargo_path." ".dependency_name)
+  let actual = SUCHVim_get_execute_dependency_commands()
+  Assert expected == actual
+
+Execute (Given not installed dependency and doesn't have cargo When check Then message is correct):
+  call SUCHVim_set_not_installed_dependencies(not_installed_dependency)
+  call SUCHVim_set_check_dependency(0)
+
+  call SUCHVim_check_cargo_dependencies(not_installed_dependency)
+  let dependency_message = SUCHVim_get_echo_dependency_commands()
+
+  let expected = "There are missing dependencies [ ".dependency_name." ], install cargo or install them manualy."
+  Assert expected == dependency_message
+
+Execute (Given installed dependency and has cargo When check Then nothing):
+  call SUCHVim_set_installed_dependencies(installed_dependency)
+  call SUCHVim_set_check_dependency(1)
+
+  call SUCHVim_check_cargo_dependencies(installed_dependency)
+
+  let expected = []
+  let actual = SUCHVim_get_execute_dependency_commands()
+  AssertEqual expected, actual
+
+Execute (Given installed dependency and doesn't have cargo When check Then nothing):
+  call SUCHVim_set_installed_dependencies(installed_dependency)
+  call SUCHVim_set_check_dependency(0)
+
+  call SUCHVim_check_cargo_dependencies(installed_dependency)
+  let dependency_message = SUCHVim_get_echo_dependency_commands()
+
+  let expected = ""
+  AssertEqual expected, dependency_message
+
+Execute (Given not installed dependencies and has npm When check Then commands are correct):
+  call SUCHVim_set_not_installed_dependencies(not_installed_dependencies)
+  call SUCHVim_set_check_dependency(1)
+
+  call SUCHVim_check_cargo_dependencies(not_installed_dependencies)
+
+  let expected = []
+  call add(expected, "!cargo install --root ".SUCHVim_cargo_path." ".dependency_name)
+  call add(expected, "!cargo install --root ".SUCHVim_cargo_path." ".other_dependency_name)
+  let actual = SUCHVim_get_execute_dependency_commands()
+  Assert expected == actual
+
+Execute (Given not installed dependencies and doesn't have cargo When check Then message is correct):
+  call SUCHVim_set_not_installed_dependencies(not_installed_dependencies)
+  call SUCHVim_set_check_dependency(0)
+
+  call SUCHVim_check_cargo_dependencies(not_installed_dependencies)
+  let dependency_message = SUCHVim_get_echo_dependency_commands()
+
+  let expected = "There are missing dependencies [ ".dependency_name." ".other_dependency_name." ], install cargo or install them manualy."
+  Assert expected == dependency_message
+
+Execute (Given mix dependencies and has cargo When check Then commands are correct):
+  call SUCHVim_set_not_installed_dependencies(not_installed_dependencies)
+  call SUCHVim_set_installed_dependencies(installed_dependencies)
+  call SUCHVim_set_check_dependency(1)
+
+  call SUCHVim_check_cargo_dependencies(dependencies)
+
+  let expected = []
+  call add(expected, "!cargo install --root ".SUCHVim_cargo_path." ".dependency_name)
+  call add(expected, "!cargo install --root ".SUCHVim_cargo_path." ".other_dependency_name)
+  let actual = SUCHVim_get_execute_dependency_commands()
+  Assert expected == actual
+
+Execute (Given mix dependencies and doesn't have cargo When check Then message is correct):
+  call SUCHVim_set_not_installed_dependencies(not_installed_dependencies)
+  call SUCHVim_set_installed_dependencies(installed_dependencies)
+  call SUCHVim_set_check_dependency(0)
+
+  call SUCHVim_check_cargo_dependencies(dependencies)
+  let dependency_message = SUCHVim_get_echo_dependency_commands()
+
+  let expected = "There are missing dependencies [ ".dependency_name." ".other_dependency_name." ], install cargo or install them manualy."
+  Assert expected == dependency_message


### PR DESCRIPTION
These changes are very very similar to the `npm_dependencies` so I'm wondering if it could be a better idea to find a more generic way to manage dependencies in order to reuse code? Just like we were talking about it the other day.