### PR TITLE
fix/dependenciesGlobalVariable

### DIFF
--- a/common/config/languages/javascript.vim
+++ b/common/config/languages/javascript.vim
@@ -10,5 +10,5 @@ let g:editorconfig_Beautifier = "~/.SUCH-Vim/common/config/languages/js-beautify
 "  Dependencies control
 " ----------------------------------------------------------------
 
-let dependencies = [ 'tern', 'eslint' ]
-autocmd FileType javascript call SUCHVim_check_npm_dependencies(dependencies)
+let s:dependencies = [ 'tern', 'eslint' ]
+autocmd FileType javascript call SUCHVim_check_npm_dependencies(s:dependencies)

--- a/common/config/languages/markdown.vim
+++ b/common/config/languages/markdown.vim
@@ -15,5 +15,5 @@ let g:vim_markdown_no_default_key_mappings = 1
 "  Dependencies control
 " ----------------------------------------------------------------
 
-let dependencies = [ 'instant-markdown-d' ]
-autocmd FileType markdown call SUCHVim_check_npm_dependencies(dependencies)
+let s:dependencies = [ 'instant-markdown-d' ]
+autocmd FileType markdown call SUCHVim_check_npm_dependencies(s:dependencies)

--- a/common/config/languages/python.vim
+++ b/common/config/languages/python.vim
@@ -19,10 +19,10 @@ autocmd FileType python autocmd BufWritePre <buffer> call SUCHVim_format_python(
 "  Dependencies control
 " ----------------------------------------------------------------
 
-let python_pip_module_dependencies = [ 'jedi', ]
-let python_pip_executable_dependencies = [ 'yapf' , 'pylint']
-autocmd FileType python call SUCHVim_check_pip_executable_dependencies(python_pip_executable_dependencies)
-autocmd FileType python call SUCHVim_check_pip_module_dependencies(python_pip_module_dependencies)
+let s:python_pip_module_dependencies = [ 'jedi', ]
+let s:python_pip_executable_dependencies = [ 'yapf' , 'pylint']
+autocmd FileType python call SUCHVim_check_pip_executable_dependencies(s:python_pip_executable_dependencies)
+autocmd FileType python call SUCHVim_check_pip_module_dependencies(s:python_pip_module_dependencies)
 
 function! SUCHVim_format_python()
     let current_cursor = getpos(".")

--- a/common/config/languages/rust.vim
+++ b/common/config/languages/rust.vim
@@ -2,16 +2,10 @@ autocmd FileType rust noremap <buffer> <leader>f :RustFmt<cr>
 autocmd FileType rust noremap <buffer> <leader>R :RustRun<cr>
 
 let g:rustfmt_autosave = 1
-" This is a little workaround to use Cargo to check syntax instead of rustc while
-" awaiting for PR #132 on rust.vim to be merged. Credit goes to @estin.
-let g:syntastic_rust_rustc_exe = 'cargo check'
-let g:syntastic_rust_rustc_fname = ''
-let g:syntastic_rust_rustc_args = '--'
-let g:syntastic_rust_checkers = ['rustc']
 
 " ----------------------------------------------------------------
 "  Dependencies control
 " ----------------------------------------------------------------
 
-let dependencies = [ 'rustfmt' ]
-autocmd FileType rust call SUCHVim_check_cargo_dependencies(dependencies)
+let s:dependencies = [ 'rustfmt' ]
+autocmd FileType rust call SUCHVim_check_cargo_dependencies(s:dependencies)

--- a/vim/config/config.vim
+++ b/vim/config/config.vim
@@ -17,3 +17,4 @@ source ~/.SUCH-Vim/vim/config/basic/syntax.vim
 
 source ~/.SUCH-Vim/vim/config/languages/latex.vim
 source ~/.SUCH-Vim/vim/config/languages/c.vim
+source ~/.SUCH-Vim/vim/config/languages/rust.vim

--- a/vim/config/languages/rust.vim
+++ b/vim/config/languages/rust.vim
@@ -1,0 +1,6 @@
+" This is a little workaround to use Cargo to check syntax instead of rustc while
+" awaiting for PR #132 on rust.vim to be merged. Credit goes to @estin.
+let g:syntastic_rust_rustc_exe = 'cargo check'
+let g:syntastic_rust_rustc_fname = ''
+let g:syntastic_rust_rustc_args = '--'
+let g:syntastic_rust_checkers = ['rustc']


### PR DESCRIPTION
fix #83 

The problem was that rust.vim overrode the `let dependencies = [...]` in javascript.vim. So the solution is simply setting those variables to private with the s: (module only).