### PR TITLE
Remove gitglutter from visual helper plugins list

### DIFF
--- a/common/plugins/visual/helpers.vim
+++ b/common/plugins/visual/helpers.vim
@@ -1,5 +1,3 @@
 Plug 'vim-airline/vim-airline'
 
-Plug 'airblade/vim-gitgutter'
-
 Plug 'yggdroot/indentline'

--- a/common/plugins/visual/themes.vim
+++ b/common/plugins/visual/themes.vim
@@ -1,7 +1,5 @@
 Plug 'flazz/vim-colorschemes'
 
-Plug 'fneu/breezy'
-
 Plug 'rakr/vim-one'
 
 Plug 'vim-airline/vim-airline-themes'


### PR DESCRIPTION
Git gutter slowed vim a lot when working with a lot of open buffers in a git project.

I also removed an unused theme.